### PR TITLE
add 'whois' in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ decorator>=4.1.2
 requests
 simplejson
 homoglyphs
+whois


### PR DESCRIPTION
'whois' module is not installed by default.